### PR TITLE
Fixed hashAggregateGetBucket function for memory order bug

### DIFF
--- a/dogqc/include/hashing.cuh
+++ b/dogqc/include/hashing.cuh
@@ -262,6 +262,7 @@ __device__ int hashAggregateGetBucket ( agg_ht<T>* ht, int32_t ht_size, uint64_t
             entry.lock.done();
         }
         entry.lock.wait();
+        __threadfence();
         done = (entry.hash == grouphash);
         if ( numLookups == ht_size ) {
             printf ( "hash table full\n" );


### PR DESCRIPTION
```c++
entry.lock.wait();   
> __threadfence();
done = (entry.hash == grouphash);
```

In the existing implementation of hash aggregation, the value of `entry.hash` may be read before `entry.lock` due to specific compiler optimizations. It will bring a wrong result that some keys may occupy multiple slots in the hash table.

The reason is, the memory order between reading lock (i.e. `while (lock != LOCK_DONE)`) and reading hash (i.e. `done = (entry.hash == grouphash)`) are not guaranteed. It expects a `__threadfence()` between them.

The bug can be easily reproduced with a simple aggregation workload. I produced it in my research project using NVIDIA A10. I can provide the testing code if needed.


Ref: 
https://github.com/Henning1/dogqc/blob/c92f3a69dc249f5f0a937e9e422636189877a1df/dogqc/include/hashing.cuh#L251C9-L272